### PR TITLE
Add contact feature with API route

### DIFF
--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { companies } from '@/lib/data';
+
+export async function GET() {
+  return NextResponse.json(companies);
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { contactRequests } from '@/lib/contacts';
+import { v4 as uuidv4 } from 'uuid';
+
+const schema = z.object({
+  companyId: z.string().optional(),
+  name: z.string(),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  message: z.string(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const data = await req.json();
+    const parsed = schema.parse(data);
+    const contact = { id: uuidv4(), createdAt: new Date().toISOString(), ...parsed };
+    contactRequests.push(contact);
+    console.log('New contact request', contact);
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
+  }
+}

--- a/app/empresa/[slug]/page.tsx
+++ b/app/empresa/[slug]/page.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { MapPin, Phone, Globe, Calendar, Award, Users, Star } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ContactForm } from '@/components/contact-form';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { RatingStars } from '@/components/rating-stars';
@@ -187,9 +189,19 @@ export default function CompanyPage({ params }: CompanyPageProps) {
                 <CardTitle>Entre em Contato</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
-                <Button className="w-full bg-orange-500 hover:bg-orange-600">
-                  Solicitar Orçamento
-                </Button>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button className="w-full bg-orange-500 hover:bg-orange-600">
+                      Solicitar Orçamento
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Solicitar Orçamento</DialogTitle>
+                    </DialogHeader>
+                    <ContactForm companyId={company.id} />
+                  </DialogContent>
+                </Dialog>
                 {company.phone && (
                   <Button variant="outline" className="w-full">
                     <Phone className="h-4 w-4 mr-2" />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
+import { Toaster } from '@/components/ui/sonner';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -27,6 +28,7 @@ export default function RootLayout({
           </main>
           <Footer />
         </div>
+        <Toaster />
       </body>
     </html>
   );

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+
+interface ContactFormProps {
+  companyId?: string;
+}
+
+export function ContactForm({ companyId }: ContactFormProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ companyId, name, email, phone, message }),
+      });
+      if (res.ok) {
+        toast({ title: 'Mensagem enviada', description: 'Entraremos em contato em breve.' });
+        setName('');
+        setEmail('');
+        setPhone('');
+        setMessage('');
+      } else {
+        toast({ title: 'Erro ao enviar', description: 'Tente novamente.' });
+      }
+    } catch (err) {
+      toast({ title: 'Erro ao enviar', description: 'Tente novamente.' });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Nome</label>
+        <Input value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">E-mail</label>
+        <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
+        <Input value={phone} onChange={(e) => setPhone(e.target.value)} />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Mensagem</label>
+        <Textarea value={message} onChange={(e) => setMessage(e.target.value)} required />
+      </div>
+      <Button type="submit" className="w-full bg-orange-500 hover:bg-orange-600" disabled={loading}>
+        {loading ? 'Enviando...' : 'Enviar'}
+      </Button>
+    </form>
+  );
+}

--- a/lib/contacts.ts
+++ b/lib/contacts.ts
@@ -1,0 +1,3 @@
+import { ContactRequest } from '@/types';
+
+export const contactRequests: ContactRequest[] = [];

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "5.2.2",
+        "uuid": "^9.0.0",
         "vaul": "^0.9.9",
         "zod": "^3.23.8"
       }
@@ -6850,6 +6851,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vaul": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.2.2",
+    "uuid": "^9.0.0",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
   }

--- a/types/index.ts
+++ b/types/index.ts
@@ -52,3 +52,12 @@ export interface SolarCalculation {
   estimatedSavings: number;
   paybackPeriod: number;
 }
+export interface ContactRequest {
+  id: string;
+  companyId?: string;
+  name: string;
+  email: string;
+  phone?: string;
+  message: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add simple API route to list companies
- add contact API route with validation and store entries in memory
- add `ContactForm` component and integrate it on company page
- add `Toaster` component in layout
- remove static export setting in `next.config.js`
- track contact request types
- update dependencies (uuid)

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_6846353be7908326a0d0312a16d42618