### PR TITLE
Add dashboard contacts view

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -23,3 +23,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
   }
 }
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') || '10', 10);
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+
+  const data = contactRequests.slice(start, end);
+  return NextResponse.json({ data, total: contactRequests.length });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+} from "@/components/ui/pagination";
+import { companies } from "@/lib/data";
+import { ContactRequest } from "@/types";
+
+export default function DashboardPage() {
+  const [requests, setRequests] = useState<ContactRequest[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const pageSize = 10;
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch(`/api/contact?page=${page}&pageSize=${pageSize}`);
+      if (res.ok) {
+        const json = await res.json();
+        setRequests(json.data);
+        setTotal(json.total);
+      }
+    };
+    load();
+  }, [page]);
+
+  const pageCount = Math.ceil(total / pageSize);
+
+  const getCompanyName = (companyId?: string) => {
+    if (!companyId) return "-";
+    const company = companies.find((c) => c.id === companyId);
+    return company ? company.name : "-";
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Contact Requests</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Company</TableHead>
+            <TableHead>Message</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {requests.map((r) => (
+            <TableRow key={r.id}>
+              <TableCell>{r.name}</TableCell>
+              <TableCell>{r.email}</TableCell>
+              <TableCell>{getCompanyName(r.companyId)}</TableCell>
+              <TableCell className="whitespace-pre-line">{r.message}</TableCell>
+            </TableRow>
+          ))}
+          {requests.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={4} className="text-center py-8">
+                No requests found
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      {pageCount > 1 && (
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setPage((p) => Math.max(1, p - 1));
+                }}
+                className={page === 1 ? "pointer-events-none opacity-50" : ""}
+              />
+            </PaginationItem>
+            {Array.from({ length: pageCount }).map((_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  href="#"
+                  isActive={i + 1 === page}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setPage(i + 1);
+                  }}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setPage((p) => Math.min(pageCount, p + 1));
+                }}
+                className={page === pageCount ? "pointer-events-none opacity-50" : ""}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose GET handler for `/api/contact`
- list contact requests with company names on a new dashboard page
- add pagination handling on that dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684643020c308326aa6ada77ea3748ae