### PR TITLE
Add LocalBusiness JSON-LD

### DIFF
--- a/app/empresa/[slug]/page.tsx
+++ b/app/empresa/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { RatingStars } from '@/components/rating-stars';
 import { VerificationBadges, useCompanyBadges } from '@/components/verification-badges';
+import { CompanyJsonLd } from '@/components/company-jsonld';
 import { companies, reviews } from '@/lib/data';
 import type { Metadata } from 'next';
 
@@ -57,6 +58,7 @@ export default function CompanyPage({ params }: CompanyPageProps) {
 
   return (
     <div className="min-h-screen">
+      <CompanyJsonLd company={company} />
       {/* Company Header */}
       <div className="relative h-64 md:h-80">
         <Image

--- a/components/company-jsonld.tsx
+++ b/components/company-jsonld.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Script from 'next/script';
+
+interface CompanyJsonLdProps {
+  company: {
+    name: string;
+    slug: string;
+    description: string;
+    logo: string;
+    phone?: string;
+    location: {
+      city: string;
+      state: string;
+    };
+    rating: number;
+    reviewCount: number;
+  };
+}
+
+export function CompanyJsonLd({ company }: CompanyJsonLdProps) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'LocalBusiness',
+    name: company.name,
+    description: company.description,
+    image: company.logo,
+    url: `https://solarreviewsbrasil.com.br/empresa/${company.slug}`,
+    telephone: company.phone,
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: company.location.city,
+      addressRegion: company.location.state,
+      addressCountry: 'BR',
+    },
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: company.rating,
+      reviewCount: company.reviewCount,
+    },
+  };
+
+  return (
+    <Script
+      id="company-jsonld"
+      type="application/ld+json"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `CompanyJsonLd` component to inject structured data
- embed JSON-LD on company pages

## Testing
- `npm run lint`
- *(failed attempt)* `curl -I https://validator.schema.org/`

------
https://chatgpt.com/codex/tasks/task_e_6846e79e14208326a10b0b517d1a1e60