### PR TITLE
Improve navigation and filter initialization

### DIFF
--- a/app/empresas/page.tsx
+++ b/app/empresas/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Search, Filter, MapPin, Star } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -11,11 +12,45 @@ import { GoogleSearch } from '@/components/google-search';
 import { companies, brazilianStates } from '@/lib/data';
 
 export default function CompaniesPage() {
+  const searchParams = useSearchParams();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedState, setSelectedState] = useState('all-states');
   const [selectedSpecialty, setSelectedSpecialty] = useState('all-specialties');
   const [minRating, setMinRating] = useState('any-rating');
   const [planFilter, setPlanFilter] = useState('all-plans');
+
+  useEffect(() => {
+    const q = searchParams.get('q');
+    const locationParam = searchParams.get('location');
+    const stateParam = searchParams.get('state');
+    const specialtyParam = searchParams.get('specialty');
+    const ratingParam = searchParams.get('rating');
+    const planParam = searchParams.get('plan');
+
+    if (q) {
+      setSearchTerm(q);
+    }
+    const loc = locationParam || stateParam;
+    if (loc) {
+      const matchedState = brazilianStates.find(state =>
+        state.name.toLowerCase().includes(loc.toLowerCase()) ||
+        loc.toLowerCase().includes(state.code.toLowerCase()) ||
+        loc.toLowerCase().includes(state.name.toLowerCase())
+      );
+      if (matchedState) {
+        setSelectedState(matchedState.code);
+      }
+    }
+    if (specialtyParam) {
+      setSelectedSpecialty(specialtyParam);
+    }
+    if (ratingParam) {
+      setMinRating(ratingParam);
+    }
+    if (planParam) {
+      setPlanFilter(planParam);
+    }
+  }, [searchParams]);
 
   // Get unique specialties
   const specialties = useMemo(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Search, Star, Award, Users, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { BannerCarousel } from '@/components/banner-carousel';
@@ -10,15 +11,16 @@ import { GoogleSearch } from '@/components/google-search';
 import { companies } from '@/lib/data';
 
 export default function Home() {
-  const premiumCompanies = companies.filter(company => 
+  const router = useRouter();
+  const premiumCompanies = companies.filter(company =>
     company.planType === 'premium' || company.planType === 'enterprise'
   );
 
   const handleSearch = (query: string, location?: string) => {
     // In a real app, this would navigate to search results
     console.log('Search:', query, 'Location:', location);
-    // For now, redirect to companies page
-    window.location.href = `/empresas?q=${encodeURIComponent(query)}${location ? `&location=${encodeURIComponent(location)}` : ''}`;
+    // For now, redirect to companies page using client-side navigation
+    router.push(`/empresas?q=${encodeURIComponent(query)}${location ? `&location=${encodeURIComponent(location)}` : ''}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- use `useRouter` to push search results instead of `window.location.href`
- read query params on the companies page and initialize filter state

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846e79d529083268d21b50f64ac12b8