### PR TITLE
Add NEXT_PUBLIC_SITE_URL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Build the project for production:
 npm run build
 ```
 
+### Environment Variables
+
+The application uses the `NEXT_PUBLIC_SITE_URL` variable to generate
+canonical URLs for pages. When running locally this defaults to
+`http://localhost:3000`. Set it to the public URL of your deployment in
+`.env.local` or your hosting provider's settings.
+
 ## Project Structure
 
 - **app/** - Next.js route handlers and pages

--- a/app/empresa/[slug]/page.tsx
+++ b/app/empresa/[slug]/page.tsx
@@ -18,7 +18,9 @@ export async function generateMetadata({ params }: CompanyPageProps): Promise<Me
 
   const title = `${company.name} | SolarReviews Brasil`;
   const description = company.description;
-  const url = `https://solarreviewsbrasil.com.br/empresa/${company.slug}`;
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const url = `${baseUrl}/empresa/${company.slug}`;
 
   return {
     title,

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,10 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: { unoptimized: true },
+  env: {
+    NEXT_PUBLIC_SITE_URL:
+      process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- configure `NEXT_PUBLIC_SITE_URL` in `next.config.js`
- use the variable in company metadata
- document the environment variable in README

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_6846e795f3d88326abcd5d5e83fd740e