### PR TITLE
Fix metadata export in client page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,5 @@
-'use client';
-
-import { Metadata } from 'next';
-import { useRouter } from 'next/navigation';
-import { Search, Star, Award, Users, Zap } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { BannerCarousel } from '@/components/banner-carousel';
-import { CompanyCard } from '@/components/company-card';
-import { SolarCalculator } from '@/components/solar-calculator';
-import { GoogleSearch } from '@/components/google-search';
-import { companies } from '@/lib/data';
-import Hero from '@/components/hero';
-import Features from '@/components/features';
-import HowItWorks from '@/components/how-it-works';
-import ContactCTA from '@/components/contact-cta';
-import { CompanySearch } from '@/components/company-search';
+import type { Metadata } from 'next';
+import HomeClient from '@/components/home-client';
 
 export const metadata: Metadata = {
   title: 'SolarReviews Brasil - Avaliações de Empresas de Energia Solar',
@@ -21,25 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
-  const router = useRouter();
-  const premiumCompanies = companies.filter(company =>
-    company.planType === 'premium' || company.planType === 'enterprise'
-  );
-
-  const handleSearch = (query: string, location?: string) => {
-    // In a real app, this would navigate to search results
-    console.log('Search:', query, 'Location:', location);
-    // For now, redirect to companies page using client-side navigation
-    router.push(`/empresas?q=${encodeURIComponent(query)}${location ? `&location=${encodeURIComponent(location)}` : ''}`);
-  };
-
-  return (
-    <main>
-      <Hero />
-      <CompanySearch onSearch={handleSearch} />
-      <Features />
-      <HowItWorks />
-      <ContactCTA />
-    </main>
-  );
+  return <HomeClient />;
 }

--- a/components/home-client.tsx
+++ b/components/home-client.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Hero from '@/components/hero';
+import Features from '@/components/features';
+import HowItWorks from '@/components/how-it-works';
+import ContactCTA from '@/components/contact-cta';
+import { CompanySearch } from '@/components/company-search';
+import { companies } from '@/lib/data';
+
+export default function HomeClient() {
+  const router = useRouter();
+  const premiumCompanies = companies.filter(
+    company => company.planType === 'premium' || company.planType === 'enterprise'
+  );
+
+  const handleSearch = (query: string, location?: string) => {
+    console.log('Search:', query, 'Location:', location);
+    router.push(
+      `/empresas?q=${encodeURIComponent(query)}${
+        location ? `&location=${encodeURIComponent(location)}` : ''
+      }`
+    );
+  };
+
+  return (
+    <main>
+      <Hero />
+      <CompanySearch onSearch={handleSearch} />
+      <Features />
+      <HowItWorks />
+      <ContactCTA />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- ensure the home page is a server component
- move client logic into new `HomeClient` component

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0fe5ed8832680f436c44cd1a8d2