### PR TITLE
Refactor contact API to use centralized storage

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,8 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { NextResponse } from 'next/server';
 import { ContactRequest } from '@/types';
-
-let contactRequests: ContactRequest[] = [];
+import { contactRequests } from '@/lib/contacts';
 
 export async function POST(request: Request) {
   const data = await request.json();


### PR DESCRIPTION
## Summary
- centralize contact request storage under `lib/contacts`
- update contact route to use this storage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846e79b41648326bcedeebf36cebe33