### PR TITLE
Add upload API route

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const file = formData.get('file') as File | null;
+
+  if (!file) {
+    return NextResponse.json({ error: 'File not provided' }, { status: 400 });
+  }
+
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+
+  const uploadDir = path.join(process.cwd(), 'public', 'uploads');
+  await fs.mkdir(uploadDir, { recursive: true });
+
+  const ext = path.extname(file.name) || `.${file.type.split('/').pop()}`;
+  const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`;
+  const filePath = path.join(uploadDir, fileName);
+
+  await fs.writeFile(filePath, buffer);
+
+  const url = `/uploads/${fileName}`;
+  return NextResponse.json({ url });
+}


### PR DESCRIPTION
## Summary
- implement `app/api/upload/route.ts` to store uploads under `public/uploads`

## Testing
- `npm run lint` *(fails: react/no-children-prop in existing files)*
- `npm run type-check` *(fails: several type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6870741f89948326ad8e9bad431a56fa