### PR TITLE
Clean up unused AppProviders import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
-import { AppProviders } from '@/components/providers';
 import { MotionProvider } from '@/components/layout/motion-provider';
 
 const inter = Inter({ subsets: ['latin'] });


### PR DESCRIPTION
## Summary
- drop unused AppProviders import from layout
- delete empty `app/providers.tsx`

## Testing
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707420f19c8326b8967ae5324d9cbd