### PR TITLE
Document NEXT_PUBLIC_API_URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ canonical URLs for pages. When running locally this defaults to
 `http://localhost:3000`. Set it to the public URL of your deployment in
 `.env.local` or your hosting provider's settings.
 
+The application also uses the `NEXT_PUBLIC_API_URL` variable to connect
+to the backend API. When this variable isn't set, it defaults to
+`http://localhost:3002`. Create a `.env.local` file to override the
+default:
+
+```bash
+# .env.local
+NEXT_PUBLIC_API_URL=http://localhost:3002
+```
+
 ## Project Structure
 
 - **app/** - Next.js route handlers and pages


### PR DESCRIPTION
## Summary
- explain how to configure `NEXT_PUBLIC_API_URL`

## Testing
- `npm run lint` *(fails: react/no-children-prop)*

------
https://chatgpt.com/codex/tasks/task_e_6870742363d48326b80feff33a9b2966